### PR TITLE
Allow default value for `path-to-changelog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       - name: Update changelog
         uses: @superfaceai/release-changelog-action@v1
         with:
-          path-to-changelog: CHANGELOG.md
+          path-to-changelog: CHANGELOG.md  # optional, default value is `CHANGELOG.md`
           version: 1.0.0
           operation: release
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ author: 'superface.ai'
 inputs:
   path-to-changelog:
     description: 'Path to changelog file in keep-a-changelog format'
-    required: true
     default: ./CHANGELOG.md
   version:
     description: 'Version to be released or read'


### PR DESCRIPTION
A default value was already set. However, due to the usage of `required: true`, it was not usable. Changelog paths are common enough that a default value is warranted.