### PR TITLE
Fix: Add support for optional chaining operator 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   changelog:
     description: 'Read or released changelog'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR  bumps version of Node.js used by this action from 12 to 16 which:

- fixes problem with ?. operator in transpiled code
- fixes deprecation warning 
<img width="258" alt="image" src="https://user-images.githubusercontent.com/5206165/203302708-0c6c0447-9841-4f2d-ac84-270b30d70056.png">

The oldest supported Node.js LTS by Github Actions is 16 according to this changelog https://github.blog/changelog/2022-05-20-actions-can-now-run-in-a-node-js-16-runtime/
