### PR TITLE
Add format input to action yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   operation:
     description: 'release | read'
     required: true
+  format:
+    description: 'Markdown format: compact (default) | markdownlint'
+    required: false
 outputs:
   changelog:
     description: 'Read or released changelog'


### PR DESCRIPTION
This PR adds format input into action.yml, to suppress following warning:
<img width="732" alt="image" src="https://user-images.githubusercontent.com/5206165/216285476-fe89a2e6-e267-4ce8-97e6-6d95efd25391.png">
