### PR TITLE
docs: remove the @ prefix from action names in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Update changelog
-        uses: @superfaceai/release-changelog-action@v2
+        uses: superfaceai/release-changelog-action@v2
         with:
           path-to-changelog: CHANGELOG.md  # optional, default value is `CHANGELOG.md`
           version: 1.0.0
@@ -46,7 +46,7 @@ jobs:
         - uses: actions/checkout@v2
         - name: Get changelog
           id: get-changelog
-          uses: @superfaceai/release-changelog-action@v2
+          uses: superfaceai/release-changelog-action@v2
           with:
             path-to-changelog: CHANGELOG.md
             version: 1.0.0


### PR DESCRIPTION
This PR removes the `@` prefix from action names in readme examples.

closes: #307 